### PR TITLE
Fix stats rendering and chart updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1058,10 +1058,11 @@ def update_floor_display(value):
         # Basic outputs (all have corresponding elements now)
         Output('yosai-custom-header', 'style'),
         Output('stats-panels-container', 'style', allow_duplicate=True),
-        Output('total-access-events-H1', 'children'),
-        Output('event-date-range-P', 'children'),
+        Output('enhanced-total-access-events-H1', 'children'),
+        Output('enhanced-event-date-range-P', 'children'),
         Output('processing-status', 'children', allow_duplicate=True),
-        Output('enhanced-metrics-store', 'data')
+        Output('enhanced-metrics-store', 'data'),
+        Output('enhanced-stats-data-store', 'data')
     ],
     Input('confirm-and-generate-button', 'n_clicks'),
     [
@@ -1082,7 +1083,8 @@ def generate_basic_analysis(n_clicks, file_data, processed_data):
             '0',         # total events
             'No data',   # date range
             "Click generate to start analysis",  # status
-            None         # metrics store
+            None,        # metrics store
+            None
         )
     
     try:
@@ -1104,6 +1106,7 @@ def generate_basic_analysis(n_clicks, file_data, processed_data):
             f"{enhanced_metrics['total_events']:,}",
             enhanced_metrics['date_range'],
             "🎉 Basic analysis complete!",
+            enhanced_metrics,
             enhanced_metrics
         )
         
@@ -1115,6 +1118,7 @@ def generate_basic_analysis(n_clicks, file_data, processed_data):
             'Error',
             'Error',
             f"❌ Analysis Error: {str(e)}",
+            None,
             None
         )
 

--- a/ui/components/enhanced_stats_handlers.py
+++ b/ui/components/enhanced_stats_handlers.py
@@ -37,14 +37,14 @@ class EnhancedStatsHandlers:
             [
                 Input('stats-refresh-interval', 'n_intervals'),
                 Input('refresh-stats-btn', 'n_clicks'),
+                Input('enhanced-metrics-store', 'data')
             ],
             [
                 State('processed-data-store', 'data'),
-                State('enhanced-metrics-store', 'data'),
             ],
             prevent_initial_call=True
         )
-        def update_enhanced_stats(n_intervals, refresh_clicks, processed_data, enhanced_metrics):
+        def update_enhanced_stats(n_intervals, refresh_clicks, enhanced_metrics, processed_data):
             """Update enhanced statistics display"""
             try:
                 if enhanced_metrics:
@@ -84,10 +84,13 @@ class EnhancedStatsHandlers:
                 Input('chart-security-btn', 'n_clicks'),
                 Input('chart-devices-btn', 'n_clicks'),
             ],
-            State('enhanced-stats-data-store', 'data'),
+            [
+                State('enhanced-stats-data-store', 'data'),
+                State('processed-data-store', 'data')
+            ],
             prevent_initial_call=True
         )
-        def update_main_chart(hourly_clicks, daily_clicks, security_clicks, devices_clicks, stats_data):
+        def update_main_chart(hourly_clicks, daily_clicks, security_clicks, devices_clicks, stats_data, processed_data):
             """Update main analytics chart based on button clicks"""
             from dash import ctx
             
@@ -96,15 +99,21 @@ class EnhancedStatsHandlers:
                 
             button_id = ctx.triggered[0]['prop_id'].split('.')[0]
             
-            # Mock data for demonstration
+            df = None
+            if processed_data and isinstance(processed_data, dict) and processed_data.get('dataframe'):
+                try:
+                    df = pd.DataFrame(processed_data['dataframe'])
+                except Exception:
+                    df = None
+
             if button_id == 'chart-hourly-btn':
-                return self.component.create_hourly_activity_chart(None)  # Would pass real data
+                return self.component.create_hourly_activity_chart(df)
             elif button_id == 'chart-daily-btn':
-                return self.component.create_daily_trends_chart(None)
+                return self.component.create_daily_trends_chart(df)
             elif button_id == 'chart-security-btn':
-                return self.component.create_security_distribution_chart(None)
+                return self.component.create_security_distribution_chart(df)
             elif button_id == 'chart-devices-btn':
-                return self.component.create_device_usage_chart(None)
+                return self.component.create_device_usage_chart(df)
             else:
                 return self.component._create_empty_chart("Unknown chart type")
                 


### PR DESCRIPTION
## Summary
- wire up stats generation to enhanced stats IDs
- trigger enhanced stats refresh when metrics store updates
- load processed data when rendering charts

## Testing
- `python -m py_compile app.py ui/components/enhanced_stats_handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_68451d2866688320b1e6c5a38b0d0598