### PR TITLE
Fix stats display with proper container ID

### DIFF
--- a/app.py
+++ b/app.py
@@ -393,11 +393,13 @@ def _create_complete_fixed_layout(app_instance, main_logo_path, icon_upload_defa
     # Choose enhanced stats implementation if available
     if components_available.get('enhanced_stats') and component_instances.get('enhanced_stats'):
         enhanced_stats_layout = [component_instances['enhanced_stats'].create_enhanced_stats_container()]
+        include_fallback_stats = False
     else:
         enhanced_stats_layout = [
             _create_fallback_enhanced_header(),
             _create_fallback_advanced_panels(),
         ]
+        include_fallback_stats = True
 
     return html.Div([
         # FIXED: yosai-custom-header (required by callbacks)
@@ -582,7 +584,7 @@ def _create_complete_fixed_layout(app_instance, main_logo_path, icon_upload_defa
             children=[
                 # All required elements for callbacks (initially hidden)
                 *enhanced_stats_layout,
-                _create_fallback_stats_container(),
+                *([_create_fallback_stats_container()] if include_fallback_stats else []),
                 _create_fallback_analytics_section(),
                 _create_fallback_charts_section(),
                 _create_fallback_export_section(),

--- a/ui/components/enhanced_stats.py
+++ b/ui/components/enhanced_stats.py
@@ -116,7 +116,9 @@ class EnhancedStatsComponent:
                     n_intervals=0,
                     disabled=True,  # Enable when real-time mode is active
                 ),
-            ]
+            ],
+            id="stats-panels-container",
+            style={"display": "none"},
         )
 
     def create_custom_header(self):


### PR DESCRIPTION
## Summary
- ensure `stats-panels-container` ID exists in enhanced stats component
- avoid adding fallback stats panel when the enhanced version is present

## Testing
- `python -m py_compile ui/components/enhanced_stats.py app.py ui/components/enhanced_stats_handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_68451f69862c8320802654c7ec8d6bd6