### PR TITLE
Update header and shrink upload area

### DIFF
--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -79,7 +79,7 @@ def create_main_header(main_logo_path):
     header_style.update({
         'display': 'flex',
         'alignItems': 'center',
-        'justifyContent': 'center',
+        'justifyContent': 'flex-start',
         'padding': f"{SPACING['md']} {SPACING['xl']}",
         'marginBottom': SPACING['xl'],
     })
@@ -88,9 +88,9 @@ def create_main_header(main_logo_path):
         children=[
             html.Img(src=main_logo_path, style={'height': '40px', 'marginRight': SPACING['base']}),
             html.H1(
-                "Enhanced Analytics Dashboard",
+                "Yōsai Intel Enhanced Analytics Dashboard",
                 style={
-                    'fontSize': TYPOGRAPHY['text_3xl'],
+                    'fontSize': TYPOGRAPHY['text_4xl'],
                     'margin': '0',
                     'color': COLORS['text_primary'],
                     'fontWeight': TYPOGRAPHY['font_semibold']

--- a/ui/themes/style_config.py
+++ b/ui/themes/style_config.py
@@ -248,9 +248,9 @@ UI_COMPONENTS = {
         'accept_types': ['.csv'],
         'max_file_size': '10MB',
         'multiple_files': False,
-        'icon_size': '120px',  # NEW: Larger icon size
-        'container_width': '70%',  # NEW: Wider container
-        'border_thickness': '3px'  # NEW: Thicker border
+        'icon_size': '60px',  # Adjusted for smaller container
+        'container_width': '35%',  # Half the previous width
+        'border_thickness': '3px'
     },
     'mapping': {
         'enabled': True,
@@ -313,24 +313,25 @@ LAYOUT_CONFIG = {
 # Centralized style definitions for UI components
 UPLOAD_STYLES = {
     'icon': {
-        'width': '120px',
-        'height': '120px',
+        'width': '60px',
+        'height': '60px',
         'marginBottom': SPACING['base'],
         'opacity': '0.8',
         'transition': f'all {ANIMATIONS["normal"]}'
     },
     'content': {
         'display': 'flex',
-        'flexDirection': 'column',
+        'flexDirection': 'row',
         'alignItems': 'center',
-        'justifyContent': 'center',
+        'justifyContent': 'space-around',
         'height': '100%',
-        'padding': SPACING['base']
+        'padding': SPACING['base'],
+        'gap': SPACING['md']
     },
     'base': {
         'width': UI_COMPONENTS['upload']['container_width'],
-        'maxWidth': '600px',
-        'minHeight': '180px',
+        'maxWidth': '300px',
+        'minHeight': '90px',
         'borderRadius': BORDER_RADIUS['lg'],
         'textAlign': 'center',
         'margin': f"{SPACING['base']} auto",


### PR DESCRIPTION
## Summary
- left-align the dashboard header and bump the font size
- halve the upload container size and switch to a landscape layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas' and 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68453a04bac08320b3aa3e768ac5a190