### PR TITLE
Fix mapping layout width and use memory store

### DIFF
--- a/app.py
+++ b/app.py
@@ -615,10 +615,10 @@ def _create_complete_fixed_layout(app_instance, main_logo_path, icon_upload_defa
         # Data stores
         dcc.Store(id='uploaded-file-store'),
         dcc.Store(id='csv-headers-store', storage_type='session'),
-        dcc.Store(id='processed-data-store', storage_type='session'),
+        dcc.Store(id='processed-data-store', storage_type='memory'),
         dcc.Store(id='enhanced-metrics-store', storage_type='session'),
         dcc.Store(id='all-doors-from-csv-store', storage_type='session'),
-        dcc.Store(id='column-mapping-store', storage_type='session'),
+        dcc.Store(id='column-mapping-store', storage_type='local'),
         dcc.Store(id='manual-door-classifications-store', storage_type='session'),
         
     ], style={

--- a/ui/themes/style_config.py
+++ b/ui/themes/style_config.py
@@ -372,9 +372,9 @@ UPLOAD_STYLES = {
 MAPPING_STYLES = {
     'section': {
         'display': 'block',
-        'width': '70%',
-        'maxWidth': '600px',
-        'margin': '0 auto',
+        'width': UPLOAD_STYLES['base']['width'],
+        'maxWidth': UPLOAD_STYLES['base']['maxWidth'],
+        'margin': f"{SPACING['base']} auto",
         'padding': '1.2rem',
         'backgroundColor': COLORS['surface'],
         'borderRadius': BORDER_RADIUS['md'],


### PR DESCRIPTION
## Summary
- align the mapping section width with the upload drop zone
- persist saved column mappings between sessions
- keep processed data in memory to avoid browser storage quota errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_684567b9473483208f965e3a6cde37e3