### PR TITLE
Fix duplicate Dash callback outputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1152,7 +1152,7 @@ def enhanced_file_upload(contents, filename):
 # Advanced view toggle callback
 @app.callback(
     [
-        Output("stats-panels-container", "style"),
+        Output("stats-panels-container", "style", allow_duplicate=True),
         Output("advanced-analytics-panels-container", "style"),
         Output("enhanced-stats-header", "style"),
         Output("advanced-view-button", "children"),
@@ -1359,11 +1359,11 @@ def update_floor_display(value):
         # Basic outputs (all have corresponding elements now)
         Output("yosai-custom-header", "style"),
         Output("stats-panels-container", "style", allow_duplicate=True),
-        Output("enhanced-total-access-events-H1", "children"),
-        Output("enhanced-event-date-range-P", "children"),
+        Output("enhanced-total-access-events-H1", "children", allow_duplicate=True),
+        Output("enhanced-event-date-range-P", "children", allow_duplicate=True),
         Output("processing-status", "children", allow_duplicate=True),
         Output("enhanced-metrics-store", "data"),
-        Output("enhanced-stats-data-store", "data"),
+        Output("enhanced-stats-data-store", "data", allow_duplicate=True),
     ],
     Input("confirm-and-generate-button", "n_clicks"),
     [

--- a/ui/components/enhanced_stats_handlers.py
+++ b/ui/components/enhanced_stats_handlers.py
@@ -28,12 +28,12 @@ class EnhancedStatsHandlers:
         """Register main stats update callback"""
         @self.app.callback(
             [
-                Output('enhanced-total-access-events-H1', 'children'),
-                Output('enhanced-event-date-range-P', 'children'),
+                Output('enhanced-total-access-events-H1', 'children', allow_duplicate=True),
+                Output('enhanced-event-date-range-P', 'children', allow_duplicate=True),
                 Output('events-trend-indicator', 'children'),
                 Output('events-trend-indicator', 'style'),
-                Output('avg-events-per-day', 'children'),
-                Output('enhanced-stats-data-store', 'data'),
+                Output('avg-events-per-day', 'children', allow_duplicate=True),
+                Output('enhanced-stats-data-store', 'data', allow_duplicate=True),
             ],
             [
                 Input('stats-refresh-interval', 'n_intervals'),
@@ -99,7 +99,7 @@ class EnhancedStatsHandlers:
                 Output('anomaly-insight', 'children'),
 
                 # Additional Activity Analysis
-                Output('avg-events-per-day', 'children'),
+                Output('avg-events-per-day', 'children', allow_duplicate=True),
                 Output('peak-activity-day', 'children'),
             ],
             [


### PR DESCRIPTION
## Summary
- allow duplicate outputs for metrics updates in UI callbacks
- enable duplicate outputs for advanced view toggle

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684581e70ca0832080386bbed772a217