### PR TITLE
Fix peak activity callback

### DIFF
--- a/app.py
+++ b/app.py
@@ -1056,7 +1056,6 @@ try:
         html.Div(id="anomaly-insight", children="Alerts: 0"),
         html.Div(id="events-trend-indicator", children="--"),
         html.Div(id="avg-events-per-day", children="No data"),
-        html.Div(id="peak-activity-day", children="No data"),
         dcc.Store(id="enhanced-stats-data-store"),
         dcc.Interval(
             id="stats-refresh-interval",

--- a/ui/components/enhanced_stats_handlers.py
+++ b/ui/components/enhanced_stats_handlers.py
@@ -100,7 +100,7 @@ class EnhancedStatsHandlers:
 
                 # Additional Activity Analysis
                 Output('avg-events-per-day', 'children', allow_duplicate=True),
-                Output('peak-activity-day', 'children'),
+                Output('peak-day-display', 'children'),
             ],
             [
                 Input('enhanced-metrics-store', 'data'),


### PR DESCRIPTION
## Summary
- patch output target for peak activity day
- remove unused hidden placeholder element

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684589006f34832080432914202b2ba2