### PR TITLE
Fix asset path to avoid duplicate modules

### DIFF
--- a/assets/app.py.backup
+++ b/assets/app.py.backup
@@ -27,8 +27,10 @@ from datetime import datetime
 import dash_cytoscape as cyto
 from datetime import datetime
 
-# Add project root to path
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Add repository root to path so we prefer the main modules
+current_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.abspath(os.path.join(current_dir, os.pardir))
+sys.path.insert(0, repo_root)
 
 # Import styling and config
 from ui.themes.style_config import (

--- a/assets/app_production.py
+++ b/assets/app_production.py
@@ -5,8 +5,10 @@ import os
 import logging
 from waitress import serve
 
-# Add project root to path
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Add repository root to path so we load real modules, not the asset copies
+current_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.abspath(os.path.join(current_dir, os.pardir))
+sys.path.insert(0, repo_root)
 
 import dash_bootstrap_components as dbc
 


### PR DESCRIPTION
## Summary
- adjust sys.path in asset scripts to prefer root modules

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement pytest-cov>=4.0.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6845a7fd06208320a3f028e83650d757