### PR TITLE
Add run script for unified startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Yōsai Dashboard
+
+This repository contains the code for the Yōsai analytics dashboard.  Two entry points existed before (`app.py` for development and `app_production.py` for production).  A new `run.py` script now consolidates these so the application can be started with a single command.
+
+## Usage
+
+```bash
+# Development mode (default)
+python run.py
+
+# or
+MODE=dev python run.py
+
+# Production mode
+python run.py prod
+
+# or
+MODE=prod python run.py
+```
+
+The script will start the development server when run in `dev` mode.  When `prod` is specified it uses Waitress to serve the app.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Unified runner for the Yōsai dashboard."""
+import os
+import sys
+
+MODE = (sys.argv[1] if len(sys.argv) > 1 else os.getenv("MODE", "dev")).lower()
+
+if MODE in ("prod", "production"):
+    from app_production import create_production_app
+    from waitress import serve
+
+    app = create_production_app()
+    serve(app.server, host="0.0.0.0", port=8050)
+else:
+    from app import app
+
+    app.run(
+        debug=True,
+        host="127.0.0.1",
+        port=8050,
+        dev_tools_hot_reload=True,
+        dev_tools_ui=True,
+        dev_tools_props_check=False,
+    )
+


### PR DESCRIPTION
## Summary
- add `run.py` as a single entry point to start the dashboard
- document how to use the new script in `README.md`

## Testing
- `python -m py_compile run.py`

------
https://chatgpt.com/codex/tasks/task_e_68465366ae308320b914bb10afc765fe