### PR TITLE
Fix upload component initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -1143,7 +1143,15 @@ print(
 
 # Register core handler callbacks
 if create_upload_handlers:
-    upload_component = create_enhanced_upload_component() if create_enhanced_upload_component else None
+    upload_component = (
+        create_enhanced_upload_component(
+            ICON_UPLOAD_DEFAULT,
+            ICON_UPLOAD_SUCCESS,
+            ICON_UPLOAD_FAIL,
+        )
+        if create_enhanced_upload_component
+        else None
+    )
     upload_handlers = create_upload_handlers(
         app,
         upload_component,


### PR DESCRIPTION
## Summary
- pass icon paths when creating upload component

## Testing
- `pytest -q` *(fails: No module named 'pandas', 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68484a4c31d08320b1c75dc8d6aa6e78