### PR TITLE
Fix missing IDs for peak activity

### DIFF
--- a/ui/components/enhanced_stats.py
+++ b/ui/components/enhanced_stats.py
@@ -451,6 +451,19 @@ class EnhancedStatsComponent:
                 ),
                 # Activity level indicator
                 html.Div(id="activity-level-indicator", style={"marginTop": "15px"}),
+                # Additional metrics required by callbacks
+                html.P(
+                    id="busiest-floor",
+                    style={"color": COLORS["text_secondary"], "marginTop": "10px"},
+                ),
+                html.P(
+                    id="entry-exit-ratio",
+                    style={"color": COLORS["text_secondary"]},
+                ),
+                html.P(
+                    id="weekend-vs-weekday",
+                    style={"color": COLORS["text_secondary"]},
+                ),
             ],
             style=panel_style,
         )


### PR DESCRIPTION
## Summary
- ensure Peak Activity panel includes callbacks fields

## Testing
- `python -m py_compile ui/components/enhanced_stats.py`

------
https://chatgpt.com/codex/tasks/task_e_684853d0253483208a992859b39aa933