### PR TITLE
Improve README about dev logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ MODE=prod python run.py
 ```
 
 The script will start the development server when run in `dev` mode.  When `prod` is specified it uses Waitress to serve the app.
+
+When starting the app in development you may see the startup logs printed twice.
+Dash enables its reloader in debug mode which launches the server in a child
+process, causing duplicate output. This is normal behaviour. To disable the
+reloader and run with a single startup sequence use production mode (e.g.
+`python run.py prod`) or set `FLASK_ENV=production` before running `run.py`.


### PR DESCRIPTION
## Summary
- clarify that Dash's reloader causes duplicate startup logs when running `python run.py`
- mention production mode or `FLASK_ENV=production` to disable the duplicate logs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848d9feeb98832092591ca3beb15675