### PR TITLE
Fix duplicate dropdown outputs

### DIFF
--- a/ui/components/mapping_handlers.py
+++ b/ui/components/mapping_handlers.py
@@ -24,44 +24,10 @@ class MappingHandlers:
         
     def register_callbacks(self):
         """Register ONLY mapping callbacks"""
-        self._register_mapping_dropdown_creator()
+        # Dropdown creation is now handled in UploadHandlers to avoid duplicate outputs
         self._register_mapping_confirmation_handler()
         # REMOVED: Any callback that outputs to 'door-classification-table-container'
 
-    def _register_mapping_dropdown_creator(self):
-        """Create mapping dropdowns when headers are available"""
-        @self.app.callback(
-            [
-                Output('dropdown-mapping-area', 'children'),
-                Output('confirm-header-map-button', 'style'),
-                Output('mapping-ui-section', 'style'),
-            ],
-            Input('csv-headers-store', 'data'),
-            prevent_initial_call=True,
-        )
-        def _create_dropdowns(headers):
-            if not headers:
-                return [], {'display': 'none'}, {'display': 'none'}
-
-            dropdowns = self.mapping_component.create_mapping_dropdowns(headers, {})
-            button_style = {
-                'display': 'block',
-                'margin': '25px auto',
-                'padding': '12px 30px',
-                'backgroundColor': COLORS['accent'],
-                'color': 'white',
-                'border': 'none',
-                'borderRadius': '8px',
-                'cursor': 'pointer',
-            }
-            section_style = {
-                'display': 'block',
-                'padding': '25px',
-                'backgroundColor': COLORS['surface'],
-                'borderRadius': '12px',
-                'margin': '20px auto',
-            }
-            return dropdowns, button_style, section_style
     
     def _register_mapping_confirmation_handler(self):
         """Mapping confirmation - NO classification outputs"""

--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -38,6 +38,7 @@ class UploadHandlers:
                 Output('csv-headers-store', 'data'),
                 Output('dropdown-mapping-area', 'children'),
                 Output('confirm-header-map-button', 'style', allow_duplicate=True),
+                Output('mapping-ui-section', 'style', allow_duplicate=True),
                 Output('interactive-setup-container', 'style'),
                 Output('processing-status', 'children', allow_duplicate=True),
                 Output('upload-icon', 'src'),
@@ -201,6 +202,7 @@ class UploadHandlers:
         return (
             None, None, [],  # file store, headers, dropdown area
             confirm_button_style_hidden,  # confirm button style
+            hide_style,  # mapping-ui-section style (hidden)
             hide_style,  # interactive setup container
             "",  # processing status
             self.icons['default'],  # upload icon src
@@ -227,6 +229,13 @@ class UploadHandlers:
             result['headers'],  # csv headers store
             result['mapping_dropdowns'],  # dropdown mapping area
             confirm_button_style_visible,  # confirm button style
+            {
+                'display': 'block',
+                'padding': '25px',
+                'backgroundColor': COLORS['surface'],
+                'borderRadius': '12px',
+                'margin': '20px auto',
+            },  # mapping-ui-section style
             show_interactive_setup_style,  # interactive setup container
             processing_status_msg,  # processing status
             self.icons['success'],  # upload icon src
@@ -254,6 +263,7 @@ class UploadHandlers:
             None, None,  # file store, headers
             [html.P(processing_status_msg, style={'color': 'red'})],  # dropdown area
             confirm_button_style_hidden,  # confirm button style
+            hide_style,  # mapping-ui-section style (hidden)
             show_interactive_setup_style,  # interactive setup container
             processing_status_msg,  # processing status
             self.icons['fail'],  # upload icon src


### PR DESCRIPTION
## Summary
- remove unused mapping dropdown callback
- handle mapping-ui-section style in upload handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: IndentationError in utils/enhanced_analytics.py)*

------
https://chatgpt.com/codex/tasks/task_e_6848f283a588832089ec005e71eb3bcf