### PR TITLE
Fix CSV/JSON uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -639,6 +639,7 @@ def _create_complete_fixed_layout(app_instance, main_logo_path: str, icon_upload
                                     ),
                                 ],
                                 className="upload-area",
+                                accept=".csv,.json",
                             )
                         ],
                     ),

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,7 +43,7 @@ DEFAULT_ICONS = {
 FILE_LIMITS = {
     'max_file_size': 10 * 1024 * 1024,  # 10MB
     'max_rows': 1_000_000,
-    'allowed_extensions': ['.csv'],
+    'allowed_extensions': ['.csv', '.json'],
     'encoding': 'utf-8'
 }
 


### PR DESCRIPTION
## Summary
- allow uploading of both CSV and JSON files
- expand secure validator to handle JSON files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848fd11bbb483209324df0485e40182