### PR TITLE
Fix missing import in enhanced_stats_handlers

### DIFF
--- a/ui/components/enhanced_stats_handlers.py
+++ b/ui/components/enhanced_stats_handlers.py
@@ -8,6 +8,7 @@ import pandas as pd
 import json
 from .enhanced_stats import create_enhanced_stats_component
 from ui.themes.style_config import COLORS, TYPOGRAPHY
+from config.settings import REQUIRED_INTERNAL_COLUMNS
 
 
 class EnhancedStatsHandlers:


### PR DESCRIPTION
## Summary
- fix NameError in `enhanced_stats_handlers` by importing `REQUIRED_INTERNAL_COLUMNS`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684904de753c8320be505baf890e13ca