### PR TITLE
Increase upload file size

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,7 +114,7 @@ from ui.themes.style_config import (
     TYPOGRAPHY,
     SPACING,
 )
-from config.settings import DEFAULT_ICONS, REQUIRED_INTERNAL_COLUMNS
+from config.settings import DEFAULT_ICONS, REQUIRED_INTERNAL_COLUMNS, FILE_LIMITS
 
 print("🚀 Starting Yōsai Enhanced Analytics Dashboard (COMPLETE FIXED VERSION WITH TYPE SAFETY)...")
 
@@ -1168,6 +1168,7 @@ if create_upload_handlers:
             "fail": ICON_UPLOAD_FAIL,
         },
         secure=True,
+        max_file_size=FILE_LIMITS["max_file_size"],
     )
     upload_handlers.register_callbacks()
 

--- a/config/security_config.py
+++ b/config/security_config.py
@@ -12,7 +12,8 @@ class SecurityConfig:
     """Security configuration settings"""
     
     # File upload security
-    max_file_size: int = 10 * 1024 * 1024  # 10MB
+    # Allow much larger uploads by default
+    max_file_size: int = 100 * 1024 * 1024  # 100MB
     allowed_mime_types: List[str] = field(default_factory=lambda: [
         'text/csv', 'text/plain', 'application/csv'
     ])

--- a/config/settings.py
+++ b/config/settings.py
@@ -41,7 +41,8 @@ DEFAULT_ICONS = {
 
 # File processing limits
 FILE_LIMITS = {
-    'max_file_size': 10 * 1024 * 1024,  # 10MB
+    # Increased to allow much larger uploads
+    'max_file_size': 100 * 1024 * 1024,  # 100MB
     'max_rows': 1_000_000,
     'allowed_extensions': ['.csv', '.json'],
     'encoding': 'utf-8'

--- a/ui/themes/style_config.py
+++ b/ui/themes/style_config.py
@@ -246,7 +246,8 @@ UI_COMPONENTS = {
     'upload': {
         'enabled': True,
         'accept_types': ['.csv'],
-        'max_file_size': '10MB',
+        # Updated to reflect new limit
+        'max_file_size': '100MB',
         'multiple_files': False,
         'icon_size': '120px',  # NEW: Larger icon size
         'container_width': '70%',  # NEW: Wider container


### PR DESCRIPTION
## Summary
- allow larger uploads by increasing the configured limits
- expose `max_file_size` option in `UploadHandlers`
- enforce the limit using the new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684914d96d0c83208476e90f7dd3f0b1