### PR TITLE
Fix Pylance port type error

### DIFF
--- a/app.py
+++ b/app.py
@@ -1743,7 +1743,8 @@ if __name__ == "__main__":
     print("   • FIXED: Improved error handling and fallback values")
 
     try:
-        app.run(
+        # Use run_server for type-checked port parameter
+        app.run_server(
             debug=True,
             host="127.0.0.1",
             port=8050,

--- a/run.py
+++ b/run.py
@@ -24,7 +24,8 @@ if MODE in ("prod", "production"):
 else:
     from app import app
 
-    app.run(
+    # Use Dash's run_server for proper type hints (expects int port)
+    app.run_server(
         debug=True,
         host="127.0.0.1",
         port=8050,


### PR DESCRIPTION
## Summary
- call `run_server` in `app.py` and `run.py` to satisfy type checker

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68493e34894483208d61bf0422f5f73f