### PR TITLE
Fix duplicate output error

### DIFF
--- a/app.py
+++ b/app.py
@@ -1667,7 +1667,7 @@ def process_uploaded_data(df: pd.DataFrame, device_attrs: Optional[pd.DataFrame]
 
 # Chart type selector callback
 @app.callback(
-    Output("main-analytics-chart", "figure"),
+    Output("main-analytics-chart", "figure", allow_duplicate=True),
     Input("chart-type-selector", "value"),
     State("processed-data-store", "data"),
     State("device-attrs-store", "data"),


### PR DESCRIPTION
## Summary
- permit duplicate outputs when dropdown updates main chart

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684959312c8c832093c3159e695205ae