### PR TITLE
Fix invalid callback output id

### DIFF
--- a/ui/components/enhanced_stats_handlers.py
+++ b/ui/components/enhanced_stats_handlers.py
@@ -438,7 +438,6 @@ class EnhancedStatsHandlers:
                 Output("entrance-devices-count", "children"),
                 Output("high-security-devices", "children"),
                 Output("efficiency-insight", "children"),
-                Output("peak-activity-day", "children"),
             ],
             Input("enhanced-stats-data-store", "data"),
             prevent_initial_call=True,
@@ -450,14 +449,11 @@ class EnhancedStatsHandlers:
             entrance_count = metrics.get("entrance_devices_count", "N/A")
             high_sec = metrics.get("high_security_devices", "N/A")
             efficiency = metrics.get("efficiency_score", "N/A")
-            peak_day = metrics.get("peak_activity_day", "N/A")
-
             return (
                 devices_per_user,
                 entrance_count,
                 high_sec,
                 efficiency,
-                peak_day,
             )
 
 


### PR DESCRIPTION
## Summary
- remove obsolete output `peak-activity-day` from enhanced stats handlers

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495ce3ab0483209c8d79526336c56d