### PR TITLE
Add graph export support

### DIFF
--- a/app.py
+++ b/app.py
@@ -183,12 +183,14 @@ try:
     from ui.components.upload_handlers import create_upload_handlers
     from ui.components.mapping_handlers import create_mapping_handlers
     from ui.components.classification_handlers import create_classification_handlers
+    from ui.components.graph_handlers import create_graph_handlers
     print(">> Handler factories imported")
 except ImportError as e:
     print(f"!! Handler factories not available: {e}")
     create_upload_handlers = None
     create_mapping_handlers = None
     create_classification_handlers = None
+    create_graph_handlers = None
 
 # Cytoscape for graphs
 try:
@@ -494,6 +496,8 @@ def _add_missing_callback_elements(base_children: List[Any], existing_ids: set) 
         'refresh-analytics', 'download-stats-csv', 'download-charts',
         'download-report', 'export-status', 'floor-slider-value',
         'stats-refresh-interval',
+        'export-graph-png', 'export-graph-json',
+        'download-graph-png', 'download-graph-json',
         # FIXED: Add Enhanced Stats Handler targets
         'enhanced-total-access-events-H1', 'enhanced-event-date-range-P',
         'events-trend-indicator', 'avg-events-per-day', 'most-active-user',
@@ -508,11 +512,11 @@ def _add_missing_callback_elements(base_children: List[Any], existing_ids: set) 
                 element = html.Div(id=element_id, style={"display": "none"})
             elif element_id == 'stats-refresh-interval':
                 element = dcc.Interval(id=element_id, disabled=True, interval=999999999)
-            elif element_id in ['export-stats-csv', 'export-charts-png', 'generate-pdf-report', 'refresh-analytics']:
+            elif element_id in ['export-stats-csv', 'export-charts-png', 'generate-pdf-report', 'refresh-analytics', 'export-graph-png', 'export-graph-json']:
                 element = html.Button(id=element_id, style={"display": "none"})
             elif element_id in ['main-analytics-chart', 'security-pie-chart', 'heatmap-chart']:
                 element = dcc.Graph(id=element_id, style={"display": "none"})
-            elif element_id in ['download-stats-csv', 'download-charts', 'download-report']:
+            elif element_id in ['download-stats-csv', 'download-charts', 'download-report', 'download-graph-png', 'download-graph-json']:
                 element = dcc.Download(id=element_id)
             elif 'store' in element_id:
                 element = dcc.Store(id=element_id)
@@ -1183,6 +1187,10 @@ if create_mapping_handlers:
 
 if create_classification_handlers:
     classification_handlers = create_classification_handlers(app)
+
+if create_graph_handlers:
+    graph_handlers = create_graph_handlers(app)
+    graph_handlers.register_callbacks()
 
 # ============================================================================
 # ENHANCED STATISTICS SETUP

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -7,7 +7,10 @@ from .components import (
     EnhancedUploadComponent,
     create_enhanced_upload_component,
     create_upload_component,
-    create_simple_upload_component
+    create_simple_upload_component,
+    create_graph_component,
+    create_graph_handlers,
+    GraphHandlers,
 )
 
 __all__ = [
@@ -15,4 +18,7 @@ __all__ = [
     'create_enhanced_upload_component', 
     'create_upload_component',
     'create_simple_upload_component',
+    'create_graph_component',
+    'create_graph_handlers',
+    'GraphHandlers',
 ]

--- a/ui/components/__init__.py
+++ b/ui/components/__init__.py
@@ -7,12 +7,17 @@ from .upload import (
     EnhancedUploadComponent,
     create_enhanced_upload_component,
     create_upload_component,
-    create_simple_upload_component
+    create_simple_upload_component,
 )
+from .graph import create_graph_component
+from .graph_handlers import create_graph_handlers, GraphHandlers
 
 __all__ = [
     'EnhancedUploadComponent',
     'create_enhanced_upload_component', 
     'create_upload_component',
     'create_simple_upload_component',
+    'create_graph_component',
+    'create_graph_handlers',
+    'GraphHandlers',
 ]

--- a/ui/components/graph.py
+++ b/ui/components/graph.py
@@ -154,6 +154,7 @@ class GraphComponent:
                     'marginRight': '10px'
                 }
             ),
+            dcc.Download(id='download-graph-png'),
             html.Button(
                 "Export Data as JSON",
                 id='export-graph-json',
@@ -164,7 +165,8 @@ class GraphComponent:
                     'padding': '8px 16px',
                     'borderRadius': '4px'
                 }
-            )
+            ),
+            dcc.Download(id='download-graph-json')
         ])
     
     def create_graph_legend(self):

--- a/ui/components/graph_handlers.py
+++ b/ui/components/graph_handlers.py
@@ -1,0 +1,56 @@
+from dash import Input, Output, State
+from dash.exceptions import PreventUpdate
+import base64
+import json
+
+
+class GraphHandlers:
+    """Callback handlers for Cytoscape graph exports."""
+
+    def __init__(self, app):
+        self.app = app
+
+    def register_callbacks(self):
+        self._register_png_export()
+        self._register_json_export()
+
+    def _register_png_export(self):
+        @self.app.callback(
+            Output("onion-graph", "generateImage"),
+            Input("export-graph-png", "n_clicks"),
+            prevent_initial_call=True,
+        )
+        def trigger_png(n_clicks):
+            if not n_clicks:
+                raise PreventUpdate
+            # Trigger client-side generation of a PNG and store it in imageData
+            return {"type": "png", "action": "store"}
+
+        @self.app.callback(
+            Output("download-graph-png", "data"),
+            Input("onion-graph", "imageData"),
+            prevent_initial_call=True,
+        )
+        def download_png(image_data):
+            if not image_data:
+                raise PreventUpdate
+            header, encoded = image_data.split(",", 1)
+            return dict(content=base64.b64decode(encoded), filename="graph.png")
+
+    def _register_json_export(self):
+        @self.app.callback(
+            Output("download-graph-json", "data"),
+            Input("export-graph-json", "n_clicks"),
+            State("onion-graph", "elements"),
+            prevent_initial_call=True,
+        )
+        def export_json(n_clicks, elements):
+            if not n_clicks:
+                raise PreventUpdate
+            data = json.dumps(elements or [], indent=2)
+            return dict(content=data, filename="graph.json")
+
+
+def create_graph_handlers(app):
+    """Factory function to create graph handlers."""
+    return GraphHandlers(app)


### PR DESCRIPTION
## Summary
- export Cytoscape graphs via new `GraphHandlers`
- expose graph handlers through the UI packages
- include download components in graph controls
- register graph handlers when the app starts
- ensure placeholder elements exist for graph export buttons

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849640d1e1c832094adb0cd6fef703d