### PR TITLE
Fix duplicate outputs in graph generation callback

### DIFF
--- a/ui/components/graph_handlers.py
+++ b/ui/components/graph_handlers.py
@@ -71,9 +71,9 @@ class GraphHandlers:
     def _register_generation_callback(self):
         @self.app.callback(
             [
-                Output("onion-graph", "elements"),
-                Output("graph-output-container", "style"),
-                Output("processing-status", "children"),
+                Output("onion-graph", "elements", allow_duplicate=True),
+                Output("graph-output-container", "style", allow_duplicate=True),
+                Output("processing-status", "children", allow_duplicate=True),
             ],
             Input("confirm-and-generate-button", "n_clicks"),
             [


### PR DESCRIPTION
## Summary
- allow duplicate outputs for graph generation to fix callback conflict

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement dash>=2.14.1)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68497d942f808320aa65618ccab3d08c