### PR TITLE
Fix duplicate Dash outputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1380,7 +1380,7 @@ def update_enhanced_stats_store(status_message: Any, processed_data: Any, device
 @app.callback(
     [
         # Only handle visibility and status - let enhanced stats handlers manage the data
-        Output("yosai-custom-header", "style"),
+        Output("yosai-custom-header", "style", allow_duplicate=True),
         Output("stats-panels-container", "style", allow_duplicate=True),
         Output("processing-status", "children", allow_duplicate=True),
     ],

--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -51,7 +51,7 @@ class UploadHandlers:
                 Output('entrance-verification-ui-section', 'style', allow_duplicate=True),
                 Output('door-classification-table-container', 'style', allow_duplicate=True),
                 Output('graph-output-container', 'style'),
-                Output('stats-panels-container', 'style'),
+                Output('stats-panels-container', 'style', allow_duplicate=True),
                 Output('yosai-custom-header', 'style', allow_duplicate=True),
                 Output('onion-graph', 'elements'),
                 Output('all-doors-from-csv-store', 'data'),


### PR DESCRIPTION
## Summary
- allow duplicate `yosai-custom-header.style` in main analysis callback
- allow duplicate `stats-panels-container.style` in upload handler

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68497e92e58c8320a0943af724399ed9