### PR TITLE
Fix duplicate output error

### DIFF
--- a/app.py
+++ b/app.py
@@ -1392,7 +1392,7 @@ def display_status_message(message: Any) -> Any:
         # Only handle visibility and status - let enhanced stats handlers manage the data
         Output("yosai-custom-header", "style", allow_duplicate=True),
         Output("stats-panels-container", "style", allow_duplicate=True),
-        Output("status-message-store", "data"),
+        Output("status-message-store", "data", allow_duplicate=True),
     ],
     Input("confirm-and-generate-button", "n_clicks"),
     [

--- a/ui/components/graph_handlers.py
+++ b/ui/components/graph_handlers.py
@@ -74,7 +74,7 @@ class GraphHandlers:
                 Output("onion-graph", "elements", allow_duplicate=True),
                 Output("graph-output-container", "style", allow_duplicate=True),
                 # Send status updates to the shared store
-                Output("status-message-store", "data"),
+                Output("status-message-store", "data", allow_duplicate=True),
             ],
             Input("confirm-and-generate-button", "n_clicks"),
             [

--- a/ui/components/mapping_handlers.py
+++ b/ui/components/mapping_handlers.py
@@ -37,7 +37,7 @@ class MappingHandlers:
                 Output('entrance-verification-ui-section', 'style', allow_duplicate=True),  # Only show/hide the section
                 Output('column-mapping-store', 'data', allow_duplicate=True),  # Save updated mappings
                 # Update status via shared store
-                Output('status-message-store', 'data'),
+                Output('status-message-store', 'data', allow_duplicate=True),
                 Output('confirm-header-map-button', 'style', allow_duplicate=True),  # Add this
  
                 # REMOVED: Output('door-classification-table-container', 'style')  ← This was causing conflict

--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -46,7 +46,7 @@ class UploadHandlers:
                 Output('mapping-ui-section', 'style', allow_duplicate=True),
                 Output('interactive-setup-container', 'style'),
                 # Store status messages in a single location
-                Output('status-message-store', 'data'),
+                Output('status-message-store', 'data', allow_duplicate=True),
                 Output('upload-icon', 'src'),
                 Output('upload-data', 'style'),
                 Output('entrance-verification-ui-section', 'style', allow_duplicate=True),


### PR DESCRIPTION
## Summary
- allow duplicate outputs for `status-message-store.data` to avoid callback conflicts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68498644abf883209dae06b19e255a54