### PR TITLE
Remove unused import in main_page

### DIFF
--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -7,7 +7,6 @@ All callbacks are handled by unified handler in app.py
 
 from dash import html, dcc
 from ui.components.classification import create_classification_component
-from ui.components.graph import create_graph_container
 
 from ui.themes.style_config import COLORS, TYPOGRAPHY, SPACING, BORDER_RADIUS
 from ui.themes.helpers import (


### PR DESCRIPTION
## Summary
- drop unused `create_graph_container` import

## Testing
- `ruff check ui/pages/main_page.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498e7f6a0c8320a2077788894f1e69