### PR TITLE
Fix duplicate outputs and callback consistency

### DIFF
--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -51,10 +51,10 @@ class UploadHandlers:
                 Output('upload-data', 'style'),
                 Output('entrance-verification-ui-section', 'style', allow_duplicate=True),
                 Output('door-classification-table-container', 'style', allow_duplicate=True),
-                Output('graph-output-container', 'style'),
+                Output('graph-output-container', 'style', allow_duplicate=True),
                 Output('stats-panels-container', 'style', allow_duplicate=True),
                 Output('yosai-custom-header', 'style', allow_duplicate=True),
-                Output('onion-graph', 'elements'),
+                Output('onion-graph', 'elements', allow_duplicate=True),
                 Output('all-doors-from-csv-store', 'data'),
                 Output('upload-icon', 'style'),
                 Output('processed-data-store', 'data')


### PR DESCRIPTION
## Summary
- ensure duplicate outputs in the upload handler use `allow_duplicate=True`

## Testing
- `python -m py_compile app.py ui/components/*.py ui/pages/*.py utils/*.py config/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684994e9288083209e63c8b2f1529a58