### PR TITLE
Fix duplicate callback outputs

### DIFF
--- a/ui/components/classification_handlers.py
+++ b/ui/components/classification_handlers.py
@@ -37,7 +37,7 @@ class ClassificationHandlers:
 
     def _register_confirm_header_mapping_handler(self):
         @callback(
-            Output("door-classification-table", "children"),
+            Output("door-classification-table", "children", allow_duplicate=True),
             Input("confirm-header-map-button", "n_clicks"),
             State("uploaded-file-store", "data"),
             State("column-mapping-store", "data"),

--- a/ui/components/enhanced_stats_handlers.py
+++ b/ui/components/enhanced_stats_handlers.py
@@ -172,12 +172,12 @@ class EnhancedStatsHandlers:
 
         @self.app.callback(
             [
-                Output("peak-hour-display", "children"),
-                Output("peak-day-display", "children"),
-                Output("peak-activity-events", "children"),
-                Output("busiest-floor", "children"),
-                Output("entry-exit-ratio", "children"),
-                Output("weekend-vs-weekday", "children"),
+                Output("peak-hour-display", "children", allow_duplicate=True),
+                Output("peak-day-display", "children", allow_duplicate=True),
+                Output("peak-activity-events", "children", allow_duplicate=True),
+                Output("busiest-floor", "children", allow_duplicate=True),
+                Output("entry-exit-ratio", "children", allow_duplicate=True),
+                Output("weekend-vs-weekday", "children", allow_duplicate=True),
             ],
             [
                 Input("enhanced-stats-data-store", "data"),


### PR DESCRIPTION
## Summary
- avoid duplicate callback conflicts across components
- allow duplicate outputs for peak activity stats and classification tables

## Testing
- `pytest -q`
- `python -m py_compile ui/components/enhanced_stats_handlers.py ui/components/classification_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_6849a2b11d7083208210bea71295b995