### PR TITLE
Fix duplicate callback for header mapping

### DIFF
--- a/ui/components/classification_handlers.py
+++ b/ui/components/classification_handlers.py
@@ -41,6 +41,7 @@ class ClassificationHandlers:
             Input("confirm-header-map-button", "n_clicks"),
             State("uploaded-file-store", "data"),
             State("column-mapping-store", "data"),
+            prevent_initial_call='initial_duplicate'
         )
         def handle_confirm_header_mapping(n_clicks, uploaded_data, column_mapping):
             if n_clicks == 0 or uploaded_data is None or column_mapping is None:


### PR DESCRIPTION
## Summary
- ensure confirm header mapping callback sets `prevent_initial_call`

## Testing
- `python -m py_compile ui/components/classification_handlers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fd8fcd8c832084c8bead8e26467d