### PR TITLE
Fix missing IDs for enhanced stats callbacks

### DIFF
--- a/app.py
+++ b/app.py
@@ -460,7 +460,9 @@ def _add_missing_callback_elements(base_children: List[Any], existing_ids: set) 
         # FIXED: Add Enhanced Stats Handler targets
         'enhanced-total-access-events-H1', 'enhanced-event-date-range-P',
         'events-trend-indicator', 'avg-events-per-day', 'most-active-user',
-        'avg-user-activity', 'unique-users-today'
+        'avg-user-activity', 'unique-users-today',
+        # Add IDs referenced by enhanced stats callbacks
+        'core-row-with-sidebar', 'peak-activity-events'
     ]
     
     for element_id in callback_targets:


### PR DESCRIPTION
## Summary
- include `core-row-with-sidebar` and `peak-activity-events` as placeholder elements when missing

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684a22bbf7848320877b742cac3d268b