### PR TITLE
Fix create_custom_header signature

### DIFF
--- a/ui/components/stats.py
+++ b/ui/components/stats.py
@@ -22,7 +22,7 @@ def create_stats_container():
     return component.create_enhanced_stats_container()
 
 
-def create_custom_header(main_logo_path):
+def create_custom_header():
     """Create the enhanced stats header."""
     component = EnhancedStatsComponent()
-    return component.create_custom_header(main_logo_path)
+    return component.create_custom_header()


### PR DESCRIPTION
## Summary
- remove unused `main_logo_path` parameter in `create_custom_header` wrapper

## Testing
- `python -m py_compile ui/components/stats.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a307f14908320b25a42767f239fb3