### PR TITLE
Fix invalid cytoscape style and wheel sensitivity

### DIFF
--- a/app.py
+++ b/app.py
@@ -497,7 +497,6 @@ def _create_mini_graph_container():
             id="mini-onion-graph",
             style={"width": "100%", "height": "300px"},
             elements=[],
-            wheelSensitivity=1,
         )
 
     return html.Div(

--- a/ui/components/graph.py
+++ b/ui/components/graph.py
@@ -79,8 +79,7 @@ class GraphComponent:
             layout=self.default_layout,
             style=cytoscape_inside_box_style,
             elements=[],
-            stylesheet=actual_default_stylesheet_for_graph,
-            wheelSensitivity=1
+            stylesheet=actual_default_stylesheet_for_graph
         )
     
     def create_node_info_display(self):

--- a/ui/themes/graph_styles.py
+++ b/ui/themes/graph_styles.py
@@ -151,7 +151,6 @@ GRAPH_STYLES = [
         'style': {
             'border-width': 5,
             'border-color': COLORS['accent'],
-            'box-shadow': '0 0 20px rgba(33, 150, 243, 0.4)',  # Fixed: use rgba instead of hex+alpha
             'z-index': 1000
         }
     },


### PR DESCRIPTION
## Summary
- remove invalid `box-shadow` property from graph styles
- drop custom `wheelSensitivity` for Cytoscape graphs

## Testing
- `pytest -q`
- `python -m py_compile app.py ui/components/graph.py ui/themes/graph_styles.py`


------
https://chatgpt.com/codex/tasks/task_e_684a6052006c83208e7e7bd1728745c6