### PR TITLE
Fix most active device table rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -2467,6 +2467,9 @@ def update_consolidated_analytics(enhanced_metrics, generate_clicks):
             if isinstance(device, dict):
                 device_name = device.get('device', f'Device {i+1}')
                 event_count = device.get('events', 0)
+            elif isinstance(device, (list, tuple)) and len(device) >= 2:
+                device_name = device[0]
+                event_count = device[1]
             else:
                 device_name = str(device)
                 event_count = 0


### PR DESCRIPTION
## Summary
- handle most-active device items provided as a list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a7d72ce588320a406181e0c9fcc8a