### PR TITLE
Fix most active device table rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -2466,15 +2466,27 @@ def update_consolidated_analytics(enhanced_metrics, generate_clicks):
         for i, device in enumerate(most_active_devices[:5]):
             if isinstance(device, dict):
                 device_name = device.get('device', f'Device {i+1}')
-                event_count = device.get('events', 0)
+                event_count = device.get('events')
+            elif isinstance(device, (list, tuple)) and len(device) >= 2:
+                device_name = device[0]
+                event_count = device[1]
             else:
                 device_name = str(device)
+                event_count = None
+
+            if not isinstance(event_count, (int, float)):
                 event_count = 0
 
             table_rows.append(
                 html.Tr([
-                    html.Td(device_name, style={"padding": "5px", "color": COLORS["text_primary"]}),
-                    html.Td(f"{event_count:,}", style={"padding": "5px", "color": COLORS["accent"]}),
+                    html.Td(
+                        device_name,
+                        style={"padding": "5px", "color": COLORS["text_primary"]},
+                    ),
+                    html.Td(
+                        f"{int(event_count):,}",
+                        style={"padding": "5px", "color": COLORS["accent"]},
+                    ),
                 ])
             )
 


### PR DESCRIPTION
## Summary
- handle most-active device items provided as a list
- guard against missing or non-numeric event counts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a7d72ce588320a406181e0c9fcc8a