### PR TITLE
Add missing analytics metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1793,6 +1793,8 @@ def process_uploaded_data(
                 .sum()
             )
             security_score = round(100 - ((denied / len(df)) * 100), 2)
+        else:
+            denied = 0
 
         devices_active_today = 0
         if (
@@ -1835,6 +1837,9 @@ def process_uploaded_data(
             weekend = df[df["Timestamp (Event Time)"].dt.weekday >= 5]
             weekday = df[df["Timestamp (Event Time)"].dt.weekday < 5]
             weekend_vs_weekday = f"{len(weekday)} weekday / {len(weekend)} weekend"
+            weekend_ratio = weekend_vs_weekday
+        else:
+            weekend_ratio = "N/A"
 
         busiest_floor = "N/A"
         security_breakdown = {}
@@ -1847,6 +1852,35 @@ def process_uploaded_data(
                 security_breakdown = (
                     device_attrs["SecurityLevel"].value_counts().to_dict()
                 )
+            entrance_devices_count = int(device_attrs.get("IsOfficialEntrance", pd.Series(dtype=int)).sum())
+            high_security_devices = (
+                device_attrs.get("SecurityLevel", pd.Series(dtype=str))
+                .astype(str)
+                .str.lower()
+                .str.contains("red")
+                .sum()
+            )
+        
+        else:
+            entrance_devices_count = 0
+            high_security_devices = 0
+
+        avg_users_per_device = unique_users / max(total_devices_count, 1)
+        device_utilization_rate = (
+            (devices_active_today / total_devices_count) * 100
+            if total_devices_count > 0
+            else 0
+        )
+        efficiency_score = device_utilization_rate
+        anomaly_count = 0
+        try:
+            from utils.enhanced_analytics import create_enhanced_anomaly_detector
+
+            detector = create_enhanced_anomaly_detector()
+            anomalies = detector.detect_anomalies(df, {})
+            anomaly_count = len(anomalies)
+        except Exception:
+            pass
 
         enhanced_metrics = {
             "total_events": total_events,
@@ -1871,6 +1905,15 @@ def process_uploaded_data(
             "date_range": date_range,
             "security_breakdown": security_breakdown,
             "security_score": security_score,
+            "avg_users_per_device": avg_users_per_device,
+            "security_events_count": int(denied),
+            "entrance_devices_count": entrance_devices_count,
+            "high_security_devices": high_security_devices,
+            "device_utilization_rate": round(device_utilization_rate, 1),
+            "weekend_vs_weekday_ratio": weekend_ratio,
+            "anomaly_count": anomaly_count,
+            "efficiency_score": round(efficiency_score, 1),
+            "num_devices": total_devices_count,
         }
 
         print(f"✅ Simple analytics calculated: {len(enhanced_metrics)} metrics")

--- a/ui/components/enhanced_stats.py
+++ b/ui/components/enhanced_stats.py
@@ -555,6 +555,20 @@ class EnhancedStatsComponent:
                                 "marginBottom": "15px",
                             },
                         ),
+                        html.P(
+                            id="avg-users-per-device",
+                            style={
+                                "color": COLORS["text_secondary"],
+                                "marginBottom": "8px",
+                            },
+                        ),
+                        html.P(
+                            id="security-events-count",
+                            style={
+                                "color": COLORS["text_secondary"],
+                                "marginBottom": "8px",
+                            },
+                        ),
                     ]
                 ),
                 # Behavior insights

--- a/ui/components/enhanced_stats_handlers.py
+++ b/ui/components/enhanced_stats_handlers.py
@@ -87,6 +87,8 @@ class EnhancedStatsHandlers:
                 Output("most-active-user", "children"),
                 Output("avg-user-activity", "children"),
                 Output("unique-users-today", "children"),
+                Output("avg-users-per-device", "children"),
+                Output("security-events-count", "children"),
             ],
             [
                 Input("enhanced-stats-data-store", "data"),
@@ -102,11 +104,13 @@ class EnhancedStatsHandlers:
                         f"Most Active: {enhanced_metrics.get('most_active_user', 'N/A')}",
                         f"Avg Events/User: {enhanced_metrics.get('avg_events_per_user', 0):.2f}",
                         f"Unique Users: {enhanced_metrics.get('unique_users', 0):,}",
+                        f"Avg Users/Device: {enhanced_metrics.get('avg_users_per_device', 0):.2f}",
+                        f"Security Events: {enhanced_metrics.get('security_events_count', 0):,}",
                     )
                 else:
-                    return "No data", "No data", "No data"
+                    return "No data", "No data", "No data", "No data", "No data"
             except Exception:
-                return "Error", "Error", "Error"
+                return "Error", "Error", "Error", "Error", "Error"
 
     def _register_device_analytics_callback(self):
         """Register Device Analytics panel callback"""


### PR DESCRIPTION
## Summary
- compute additional metrics like avg users per device and security event counts
- show new metrics in user patterns panel
- update user patterns callback to populate new fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a811e60688320b9f5540c279fd665