### PR TITLE
Clean up callbacks and add chart constant

### DIFF
--- a/app.py
+++ b/app.py
@@ -1361,16 +1361,6 @@ register_all_callbacks_safely(app)
 
 
 # Advanced view toggle callback
-# @app.callback(  # Disabled old callback
-#     [
-#         Output("stats-panels-container", "style", allow_duplicate=True),
-#         Output("advanced-analytics-panels-container", "style"),
-#         Output("enhanced-stats-header", "style"),
-#         Output("advanced-view-button", "children"),
-#     ],
-#     Input("advanced-view-button", "n_clicks"),
-#     prevent_initial_call=True,
-# )
 def toggle_advanced_view(
     n_clicks: Optional[int],
 ) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any], str]:
@@ -1409,16 +1399,6 @@ def toggle_advanced_view(
 
 
 # FIXED: Debug callback with complete type safety
-# @app.callback(  # Disabled old callback
-#     [
-#         Output("debug-metrics-count", "children"),
-#         Output("debug-metrics-keys", "children"),
-#         Output("debug-processed-data", "children"),
-#         Output("debug-calculation-status", "children"),
-#     ],
-#     [Input("enhanced-stats-data-store", "data"), Input("processed-data-store", "data")],
-#     prevent_initial_call=True,
-# )
 def update_debug_info(
     metrics_data: Any, processed_data: Any
 ) -> Tuple[str, str, str, str]:
@@ -1460,14 +1440,6 @@ def update_debug_info(
 
 
 # FIXED: Container sync callback with complete type safety
-# @app.callback(  # Disabled old callback
-#     [
-#         Output("core-row-with-sidebar", "children"),
-#         Output("advanced-analytics-panels-container", "children"),
-#     ],
-#     Input("enhanced-stats-data-store", "data"),
-#     prevent_initial_call=True,
-# )
 def sync_containers_with_stats(enhanced_metrics: Any) -> Tuple[Any, Any]:
     """Keep container layouts stable when stats update."""
 
@@ -1481,13 +1453,6 @@ def sync_containers_with_stats(enhanced_metrics: Any) -> Tuple[Any, Any]:
 
 
 # FIXED: Enhanced stats store callback with complete validation
-# @app.callback(  # Disabled old callback
-#     Output("enhanced-stats-data-store", "data"),
-#     Input("status-message-store", "data"),
-#     State("processed-data-store", "data"),
-#     State("manual-door-classifications-store", "data"),
-#     prevent_initial_call=True,
-# )
 def update_enhanced_stats_store(
     status_message: Any, processed_data: Any, device_classifications: Any
 ) -> Dict[str, Any]:
@@ -1551,31 +1516,13 @@ def update_enhanced_stats_store(
 
 
 # Single callback to update the visible processing status message
-# @app.callback(  # Disabled old callback
-#     Output("processing-status", "children"),
-#     Input("status-message-store", "data"),
-#     prevent_initial_call=True,
-# )
 def display_status_message(message: Any) -> Any:
     """Display the latest processing status message."""
     return message
 
 
 # Main analysis callback - MODIFIED to avoid conflicts
-# @app.callback(  # Disabled old callback
-#     [
-#         Output("yosai-custom-header", "style", allow_duplicate=True),
-#         Output("stats-panels-container", "style", allow_duplicate=True),
-#         Output("status-message-store", "data", allow_duplicate=True),
-#     ],
-#     Input("confirm-and-generate-button", "n_clicks"),
-#     [
-#         State("uploaded-file-store", "data"),
-#         State("processed-data-store", "data"),
-#         State("manual-door-classifications-store", "data"),
-#     ],
-#     prevent_initial_call=True,
-# )
+# Main analysis callback - MODIFIED to avoid conflicts
 def generate_enhanced_analysis(
     n_clicks: Optional[int],
     file_data: Any,
@@ -1885,13 +1832,6 @@ def process_uploaded_data(
 
 
 # Chart type selector callback
-# @app.callback(  # Disabled old callback
-#     Output("main-analytics-chart", "figure", allow_duplicate=True),
-#     Input("chart-type-selector", "value"),
-#     State("processed-data-store", "data"),
-#     State("device-attrs-store", "data"),
-#     prevent_initial_call=True,
-# )
 def update_main_chart(chart_type: str, processed_data: Any, device_attrs: Any):
     """Update main analytics chart based on dropdown selection"""
     import pandas as pd
@@ -1936,23 +1876,6 @@ def update_main_chart(chart_type: str, processed_data: Any, device_attrs: Any):
 
 
 # Export callback
-# @app.callback(  # Disabled old callback
-#     [
-#         Output("download-stats-csv", "data"),
-#         Output("download-charts", "data"),
-#         Output("download-report", "data"),
-#         Output("export-status", "children"),
-#     ],
-#     [
-#         Input("export-stats-csv", "n_clicks"),
-#         Input("export-charts-png", "n_clicks"),
-#         Input("generate-pdf-report", "n_clicks"),
-#         Input("refresh-analytics", "n_clicks"),
-#     ],
-#     State("enhanced-stats-data-store", "data"),
-#     State("main-analytics-chart", "figure"),
-#     prevent_initial_call=True,
-# )
 def handle_export_actions(
     csv_clicks: Optional[int],
     png_clicks: Optional[int],

--- a/ui/components/enhanced_stats.py
+++ b/ui/components/enhanced_stats.py
@@ -13,7 +13,14 @@ import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
 import json
-from ui.themes.style_config import COLORS, SPACING, BORDER_RADIUS, SHADOWS, TYPOGRAPHY
+from ui.themes.style_config import (
+    COLORS,
+    SPACING,
+    BORDER_RADIUS,
+    SHADOWS,
+    TYPOGRAPHY,
+    CHART_HEIGHT,
+)
 from config.settings import REQUIRED_INTERNAL_COLUMNS, SECURITY_LEVELS
 
 
@@ -649,7 +656,7 @@ class EnhancedStatsComponent:
                             [
                                 dcc.Graph(
                                     id="main-analytics-chart",
-                                    style={"height": "400px"},
+                                    style={"height": f"{CHART_HEIGHT}px"},
                                     config={
                                         "displayModeBar": True,
                                         "displaylogo": False,

--- a/ui/components/mapping.py
+++ b/ui/components/mapping.py
@@ -53,7 +53,7 @@ class MappingComponent:
             style=MAPPING_STYLES['confirm_button']
         )
     
-    def create_mapping_dropdowns(self, headers, loaded_col_map_prefs=None):
+    def _create_mapping_dropdowns(self, headers, loaded_col_map_prefs=None):
         """
         Creates dropdown components for column mapping with improved layout
         
@@ -300,7 +300,7 @@ def create_mapping_section():
     component = MappingComponent()
     return component.create_mapping_section()
 
-def create_mapping_dropdowns(headers, saved_preferences=None):
+def _create_mapping_dropdowns(headers, saved_preferences=None):
     """Create mapping dropdowns"""
     component = MappingComponent()
-    return component.create_mapping_dropdowns(headers, saved_preferences)
+    return component._create_mapping_dropdowns(headers, saved_preferences)

--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -226,7 +226,7 @@ class UploadHandlers:
             from ui.components.mapping import create_mapping_component
             mapping_component = create_mapping_component()
             loaded_col_map_prefs = mapping_result['current_preferences']
-            return mapping_component.create_mapping_dropdowns(headers, loaded_col_map_prefs)
+            return mapping_component._create_mapping_dropdowns(headers, loaded_col_map_prefs)
         except ImportError:
             return [html.P("Mapping component not available", style={'color': 'orange'})]
     

--- a/ui/themes/style_config.py
+++ b/ui/themes/style_config.py
@@ -93,6 +93,9 @@ SHADOWS = {
     'outline': '0 0 0 3px rgba(33, 150, 243, 0.5)'  # Focus outline
 }
 
+# Default height for charts (px)
+CHART_HEIGHT = 400
+
 # Enhanced Typography - Building on existing
 ENHANCED_TYPOGRAPHY = {
     **TYPOGRAPHY,
@@ -683,6 +686,7 @@ __all__ = [
     'SPACING',
     'BORDER_RADIUS',
     'SHADOWS',
+    'CHART_HEIGHT',
     'COMPONENT_STYLES',
     'UPLOAD_STYLES',
     'MAPPING_STYLES',


### PR DESCRIPTION
## Summary
- remove disabled callback code
- rename mapping dropdown helper to use private naming
- centralize chart height constant
- apply constant in enhanced stats graphs

## Testing
- `python -m py_compile app.py ui/components/enhanced_stats.py ui/components/mapping.py ui/components/upload_handlers.py ui/themes/style_config.py`

------
https://chatgpt.com/codex/tasks/task_e_684a864feb50832083a4a600d67fa7f8