### PR TITLE
Fix graph container visibility and add debug

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,22 @@ from typing import Dict, Any, Union, Optional, List, Tuple
 import math
 
 
+# Dependency validation helper
+def validate_graph_dependencies() -> bool:
+    """Check availability of graph libraries and warn if missing"""
+    missing = []
+    if not components_available.get("cytoscape"):
+        missing.append("dash_cytoscape")
+    if not components_available.get("plotly"):
+        missing.append("plotly")
+
+    if missing:
+        print(f"WARNING: Missing graph dependencies: {missing}")
+        print("Install with: pip install dash-cytoscape plotly")
+        return False
+    return True
+
+
 # Type-safe JSON serialization
 def make_json_serializable(
     data: Any,
@@ -226,6 +242,9 @@ print(f">> Component Detection Complete:")
 for component, available in components_available.items():
     status = "[ACTIVE]" if available else "[FALLBACK]"
     print(f"   {component}: {status}")
+
+if not validate_graph_dependencies():
+    print("Some graph features may not work")
 
 # ============================================================================
 # CREATE DASH APP WITH FIXED LAYOUT
@@ -501,7 +520,9 @@ def _create_mini_graph_container():
         )
 
     return html.Div(
-        id="mini-graph-container", style={"display": "none"}, children=[mini_graph]
+        id="mini-graph-container",
+        style={"display": "block"},
+        children=[mini_graph],
     )
 
 
@@ -579,7 +600,7 @@ def _add_missing_callback_elements(base_children: List[Any], existing_ids: set) 
                 "security-pie-chart",
                 "heatmap-chart",
             ]:
-                element = dcc.Graph(id=element_id, style={"display": "none"})
+                element = dcc.Graph(id=element_id, style={"height": "400px"})
             elif element_id in [
                 "download-stats-csv",
                 "download-charts",
@@ -1196,7 +1217,10 @@ def _add_missing_elements_to_existing_layout(
             "graph-output-container": (
                 create_graph_container()
                 if create_graph_container
-                else html.Div(id="graph-output-container", style={"display": "none"})
+                else html.Div(
+                    id="graph-output-container",
+                    style={"display": "block"},
+                )
             ),
             "mini-graph-container": _create_mini_graph_container(),
             "debug-panel": create_debug_panel(),

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1033,3 +1033,18 @@ html, body {
   zoom: 1 !important;        /* neutralises any rogue zoom */
   transform: none !important;
 }
+
+/* Force graph containers to be visible */
+#graph-output-container {
+  display: block !important;
+  min-height: 400px;
+  border: 1px solid #ccc;
+  margin: 20px auto;
+  padding: 20px;
+}
+
+#onion-graph {
+  display: block !important;
+  width: 100%;
+  height: 600px;
+}

--- a/ui/components/graph_handlers.py
+++ b/ui/components/graph_handlers.py
@@ -85,13 +85,20 @@ class GraphHandlers:
             prevent_initial_call=True,
         )
         def generate_graph_from_data(n_clicks, processed_data, mappings, classifications):
+            print(
+                f"Graph generation triggered: clicks={n_clicks}, has_data={bool(processed_data)}"
+            )
+
             if not n_clicks or not processed_data:
+                print("Preventing update: no clicks or no data")
                 raise PreventUpdate
 
             try:
                 df = pd.DataFrame(processed_data.get("dataframe", []))
+                print(f"DataFrame created: {len(df)} rows")
                 if df.empty:
-                    return [], {"display": "none"}, "No data to generate graph"
+                    print("DataFrame is empty")
+                    return [], {"display": "block"}, "No data to generate graph"
 
                 door_col = "DoorID (Device Name)"
                 ts_col = "Timestamp (Event Time)"
@@ -140,9 +147,11 @@ class GraphHandlers:
                 unique_edges = {e["data"]["id"]: e for e in edges}
 
                 elements = nodes + list(unique_edges.values())
-                return elements, {"display": "block"}, "Analysis complete"
-            except Exception:
-                return [], {"display": "none"}, "Failed to generate graph"
+                print(f"Generated {len(elements)} graph elements")
+                return elements, {"display": "block"}, f"Graph generated with {len(elements)} elements"
+            except Exception as e:
+                print(f"Error generating graph: {e}")
+                return [], {"display": "block"}, f"Error: {str(e)}"
 
 
 # Factory function

--- a/ui/orchestrator.py
+++ b/ui/orchestrator.py
@@ -72,12 +72,21 @@ def update_graph_elements(processed_data: dict | None, doors_data: list | None, 
 @callback(
     Output("graph-output-container", "style"),
     Input("onion-graph", "elements"),
-    prevent_initial_call=True,
+    prevent_initial_call=False,
 )
 def update_container_visibility(elements: list) -> dict:
-    if elements:
-        return {"display": "block", "margin": "20px auto", "padding": "20px"}
-    return {"display": "none"}
+    if elements and len(elements) > 0:
+        return {
+            "display": "block",
+            "margin": "20px auto",
+            "padding": "20px",
+            "width": "100%",
+        }
+    return {
+        "display": "block",
+        "margin": "20px auto",
+        "padding": "20px",
+    }
 
 
 @callback(


### PR DESCRIPTION
## Summary
- display graph containers by default instead of hiding them
- allow charts to be visible when generated
- show graph container on initial load
- add debug prints in graph generation
- validate graph dependencies on startup
- keep mini graph container visible
- ensure CSS shows graph elements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a8c7e4ee88320b9332d023169c22d