### PR TITLE
Fix pylance warnings in enhanced analytics

### DIFF
--- a/utils/enhanced_analytics.py
+++ b/utils/enhanced_analytics.py
@@ -164,7 +164,10 @@ class EnhancedDataProcessor:
     
     def _calculate_activity_intensity(self, hourly_counts: pd.Series) -> str:
         """Calculate activity intensity level"""
-        variance = float(hourly_counts.var())
+        # pandas returns a "Scalar" type here which Pylance flags as not directly
+        # convertible to ``float``. Convert the series to ``numpy`` explicitly
+        # before calculating the variance to keep the static type checkers happy.
+        variance = float(np.var(hourly_counts.to_numpy(dtype=float)))
         
         if variance > 1000:
             return "High"
@@ -187,7 +190,7 @@ class EnhancedDataProcessor:
             if current_start is None:
                 current_start = hour
                 current_end = hour
-            elif hour == current_end + 1:
+            elif current_end is not None and hour == current_end + 1:
                 current_end = hour
             else:
                 periods.append((current_start, current_end))


### PR DESCRIPTION
## Summary
- silence Pylance type warnings about variance calculation
- prevent Optional value arithmetic in rush hour detection

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684aadfc3b5c83208a6eacf0cc259f47