### PR TITLE
Align analytics container usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -264,7 +264,7 @@ print(f">> Assets loaded: {ICON_UPLOAD_DEFAULT}")
 def _create_fallback_stats_container():
     """Create fallback stats container with all required callback elements"""
     return html.Div(
-        id="stats-panels-container",
+        id="analytic-stats-container",
         style={"display": "block", "minHeight": "200px"},
         children=[
             html.Div(
@@ -852,83 +852,6 @@ def _create_complete_fixed_layout(
         html.Div(
             id="tab-content",
             children=[
-                # Your 3 panels container
-                html.Div(
-                    id="stats-panels-container",
-                    style={"display": "flex", "gap": "20px", "marginBottom": "30px"},
-                    children=[
-                        # Panel 1: Access Events
-                        html.Div(
-                            style={
-                                "flex": "1",
-                                "backgroundColor": COLORS["surface"],
-                                "padding": "20px",
-                                "borderRadius": "8px",
-                                "textAlign": "center",
-                            },
-                            children=[
-                                html.H3("Access Events"),
-                                html.H1(id="total-access-events-H1", children="0"),
-                                html.P(id="event-date-range-P", children="No data"),
-                            ],
-                        ),
-                        # Panel 2: User Stats
-                        html.Div(
-                            style={
-                                "flex": "1",
-                                "backgroundColor": COLORS["surface"],
-                                "padding": "20px",
-                                "borderRadius": "8px",
-                                "textAlign": "center",
-                            },
-                            children=[
-                                html.H3("User Analytics"),
-                                html.P(id="stats-unique-users", children="0 users"),
-                                html.P(
-                                    id="stats-avg-events-per-user",
-                                    children="Avg: 0 events/user",
-                                ),
-                                html.P(id="stats-most-active-user", children="No data"),
-                                html.P(
-                                    id="stats-devices-per-user",
-                                    children="Avg: 0 users/device",
-                                ),
-                                html.P(id="stats-peak-hour", children="Peak: N/A"),
-                                html.P(id="total-devices-count", children="0 devices"),
-                                html.P(
-                                    id="entrance-devices-count", children="0 entrances"
-                                ),
-                                html.P(
-                                    id="high-security-devices",
-                                    children="0 high security",
-                                ),
-                            ],
-                        ),
-                        # Panel 3: Activity Insights
-                        html.Div(
-                            style={
-                                "flex": "1",
-                                "backgroundColor": COLORS["surface"],
-                                "padding": "20px",
-                                "borderRadius": "8px",
-                                "textAlign": "center",
-                            },
-                            children=[
-                                html.H3("Activity Insights"),
-                                html.P(id="peak-hour-display", children="Peak: N/A"),
-                                html.P(id="busiest-floor", children="Floor: N/A"),
-                                html.P(
-                                    id="traffic-pattern-insight",
-                                    children="Pattern: N/A",
-                                ),
-                                html.P(
-                                    id="security-score-insight", children="Score: N/A"
-                                ),
-                                html.P(id="anomaly-insight", children="Alerts: 0"),
-                            ],
-                        ),
-                    ],
-                ),
                 # All required elements for callbacks (initially hidden)
                 *enhanced_stats_layout,
                 _create_fallback_analytics_section(),
@@ -1190,7 +1113,7 @@ def _add_missing_elements_to_existing_layout(
         # FIXED: Add other required elements that might be missing
         required_elements = {
             "enhanced-stats-header": _create_fallback_enhanced_header(),
-            "stats-panels-container": _create_fallback_stats_container(),
+            "analytic-stats-container": _create_fallback_stats_container(),
             "advanced-analytics-panels-container": _create_advanced_analytics_container(),
             "analytics-section": _create_fallback_analytics_section(),
             "charts-section": _create_fallback_charts_section(),

--- a/assets/scripts/setup_missing_files
+++ b/assets/scripts/setup_missing_files
@@ -102,7 +102,7 @@ from dash import html
 def create_enhanced_stats_component():
     """Create basic stats component"""
     return html.Div([
-        html.Div(id='stats-panels-container', style={'display': 'none'})
+        html.Div(id='analytic-stats-container', style={'display': 'none'})
     ])
 
 class EnhancedStatsComponent:

--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -54,7 +54,7 @@ class UploadHandlers:
                 Output('entrance-verification-ui-section', 'style', allow_duplicate=True),
                 Output('door-classification-table-container', 'style', allow_duplicate=True),
                 Output('graph-output-container', 'style', allow_duplicate=True),
-                Output('stats-panels-container', 'style', allow_duplicate=True),
+                Output('analytic-stats-container', 'style', allow_duplicate=True),
                 Output('yosai-custom-header', 'style', allow_duplicate=True),
                 Output('onion-graph', 'elements', allow_duplicate=True),
                 Output('all-doors-from-csv-store', 'data'),
@@ -245,7 +245,7 @@ class UploadHandlers:
             "",  # status message store
             self.icons['default'],  # upload icon src
             upload_styles['initial'],  # upload box style
-            hide_style, hide_style, hide_style, hide_style,  # various containers
+            hide_style, hide_style, hide_style, hide_style,  # various containers (entrance, table, graph, analytic stats)
             hide_style,  # yosai header
             [],  # graph elements
             None,  # all doors store
@@ -278,7 +278,7 @@ class UploadHandlers:
             processing_status_msg,  # status message store
             self.icons['success'],  # upload icon src
             upload_styles['success'],  # upload box style
-            hide_style, hide_style, hide_style, hide_style,  # various containers
+            hide_style, hide_style, hide_style, hide_style,  # various containers (entrance, table, graph, analytic stats)
             hide_style,  # yosai header
             [],  # graph elements
             result['all_unique_doors'],  # all doors store
@@ -306,7 +306,7 @@ class UploadHandlers:
             processing_status_msg,  # status message store
             self.icons['fail'],  # upload icon src
             upload_styles['error'],  # upload box style
-            hide_style, hide_style, hide_style, hide_style,  # various containers
+            hide_style, hide_style, hide_style, hide_style,  # various containers (entrance, table, graph, analytic stats)
             hide_style,  # yosai header
             [],  # graph elements
             None,  # all doors store

--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -344,8 +344,6 @@ def create_results_section():
             ]
         ),
 
-        # Statistics Panels (hidden)
-        create_stats_panels(),
 
         # Graph Container (hidden)
         # Removed duplicate onion graph component. The graph
@@ -381,56 +379,6 @@ def create_results_section():
         )
     ])
 
-
-def create_stats_panels():
-    """Statistics panels"""
-    panel_style = get_card_container_style(padding=SPACING['lg'], margin_bottom='0')
-    panel_style.update({
-        'flex': '1',
-        'margin': f"0 {SPACING['sm']}",
-        'textAlign': 'center',
-        'minWidth': '200px'
-    })
-
-    return html.Div(
-        id='stats-panels-container',
-        style={'display': 'none'},
-        children=[
-            # Access Events Panel
-            html.Div([
-                html.H3("Access Events", style={'color': COLORS['text_primary'], 'marginBottom': SPACING['sm']}),
-                html.H1(id="total-access-events-H1", style={'color': COLORS['accent'], 'margin': f"{SPACING['sm']} 0"}),
-                html.P(id="event-date-range-P", style={'color': COLORS['text_secondary'], 'fontSize': '0.9rem'}),
-                html.Table([html.Tbody(id='most-active-devices-table-body')])
-            ], style=panel_style),
-
-            # User Analytics Panel
-            html.Div([
-                html.H3("User Analytics", style={'color': COLORS['text_primary'], 'marginBottom': SPACING['sm']}),
-                html.P(id="stats-unique-users", style={'color': COLORS['text_secondary']}),
-                html.P(id="stats-avg-events-per-user", style={'color': COLORS['text_secondary']}),
-                html.P(id="stats-most-active-user", style={'color': COLORS['text_secondary']}),
-                html.P(id="stats-devices-per-user", style={'color': COLORS['text_secondary']}),
-                html.P(id="stats-peak-hour", style={'color': COLORS['text_secondary']}),
-                html.P(id="total-devices-count", style={'color': COLORS['text_secondary']}),
-                html.P(id="entrance-devices-count", style={'color': COLORS['text_secondary']}),
-                html.P(id="high-security-devices", style={'color': COLORS['text_secondary']})
-            ], style=panel_style),
-
-            # Activity & Security Panel
-            html.Div([
-                html.H3("Activity & Security", style={'color': COLORS['text_primary'], 'marginBottom': SPACING['sm']}),
-                html.P(id="peak-hour-display", style={'color': COLORS['text_secondary']}),
-                html.P(id="peak-day-display", style={'color': COLORS['text_secondary']}),
-                html.P(id="busiest-floor", style={'color': COLORS['text_secondary']}),
-                html.P(id="entry-exit-ratio", style={'color': COLORS['text_secondary']}),
-                html.P(id="weekend-vs-weekday", style={'color': COLORS['text_secondary']}),
-                html.Div(id="security-level-breakdown", style={'color': COLORS['text_secondary']}),
-                html.P(id="compliance-score", style={'color': COLORS['text_secondary']}),
-                html.P(id="anomaly-alerts", style={'color': COLORS['text_secondary']})
-            ], style=panel_style)
-        ]
-    )
 
 
 def create_data_stores():


### PR DESCRIPTION
## Summary
- switch upload handler outputs to use `analytic-stats-container`
- drop obsolete `stats-panels-container` from main layout
- create fallback analytics container with the new id
- update placeholder setup script

## Testing
- `python -m py_compile app.py ui/components/upload_handlers.py ui/pages/main_page.py enhanced_stats.py`

------
https://chatgpt.com/codex/tasks/task_e_684ab480df548320a0b04bd36e66338f