### PR TITLE
Enable default graph display

### DIFF
--- a/app.py
+++ b/app.py
@@ -938,7 +938,7 @@ def _create_complete_fixed_layout(
                     create_graph_container()
                     if create_graph_container
                     else html.Div(
-                        id="graph-output-container", style={"display": "none"}
+                        id="graph-output-container", style={"display": "block"}
                     )
                 ),
                 _create_mini_graph_container(),
@@ -1198,7 +1198,7 @@ def _add_missing_elements_to_existing_layout(
             "graph-output-container": (
                 create_graph_container()
                 if create_graph_container
-                else html.Div(id="graph-output-container", style={"display": "none"})
+                else html.Div(id="graph-output-container", style={"display": "block"})
             ),
             "mini-graph-container": _create_mini_graph_container(),
             "debug-panel": create_debug_panel(),

--- a/ui/components/graph.py
+++ b/ui/components/graph.py
@@ -41,7 +41,7 @@ class GraphComponent:
         """Creates the complete graph visualization container"""
         return html.Div(
             id='graph-output-container',
-            style={'display': 'none'},
+            style={'display': 'block'},
             children=[
                 self.create_graph_title(),
                 self.create_graph_area(),
@@ -88,7 +88,7 @@ class GraphComponent:
         return html.Pre(
             id='tap-node-data-output',
             style=tap_node_data_centered_style,
-            children="Upload a file, map headers, (optionally classify doors), then Confirm & Generate. Tap a node for its details."
+            children="Awaiting data…"
         )
     
     def create_graph_controls(self):

--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -233,6 +233,7 @@ class UploadHandlers:
     def _get_initial_state_values(self, upload_styles):
         """Get initial state values for all outputs"""
         hide_style = {'display': 'none'}
+        show_graph_style = {'display': 'block'}
         show_interactive_setup_style = get_interactive_setup_style(True)
         confirm_button_style_hidden = UPLOAD_STYLES['generate_button'].copy()
         confirm_button_style_hidden['display'] = 'none'
@@ -245,7 +246,7 @@ class UploadHandlers:
             "",  # status message store
             self.icons['default'],  # upload icon src
             upload_styles['initial'],  # upload box style
-            hide_style, hide_style, hide_style, hide_style,  # various containers
+            hide_style, hide_style, show_graph_style, hide_style,  # various containers
             hide_style,  # yosai header
             [],  # graph elements
             None,  # all doors store
@@ -257,6 +258,7 @@ class UploadHandlers:
     def _create_success_response(self, result, upload_styles, filename):
         """Create response for successful upload"""
         hide_style = {'display': 'none'}
+        show_graph_style = {'display': 'block'}
         show_interactive_setup_style = get_interactive_setup_style(True)
         confirm_button_style_visible = UPLOAD_STYLES['generate_button']
         
@@ -278,7 +280,7 @@ class UploadHandlers:
             processing_status_msg,  # status message store
             self.icons['success'],  # upload icon src
             upload_styles['success'],  # upload box style
-            hide_style, hide_style, hide_style, hide_style,  # various containers
+            hide_style, hide_style, show_graph_style, hide_style,  # various containers
             hide_style,  # yosai header
             [],  # graph elements
             result['all_unique_doors'],  # all doors store
@@ -290,6 +292,7 @@ class UploadHandlers:
     def _create_error_response(self, result, upload_styles, filename):
         """Create response for failed upload"""
         hide_style = {'display': 'none'}
+        show_graph_style = {'display': 'block'}
         show_interactive_setup_style = get_interactive_setup_style(True)
         confirm_button_style_hidden = UPLOAD_STYLES['generate_button'].copy()
         confirm_button_style_hidden['display'] = 'none'
@@ -306,7 +309,7 @@ class UploadHandlers:
             processing_status_msg,  # status message store
             self.icons['fail'],  # upload icon src
             upload_styles['error'],  # upload box style
-            hide_style, hide_style, hide_style, hide_style,  # various containers
+            hide_style, hide_style, show_graph_style, hide_style,  # various containers
             hide_style,  # yosai header
             [],  # graph elements
             None,  # all doors store


### PR DESCRIPTION
## Summary
- show graph container by default instead of hiding it
- display placeholder text while waiting for analysis
- keep container visible after uploading files or when errors occur

## Testing
- `python -m compileall -q ./`

------
https://chatgpt.com/codex/tasks/task_e_684ab49daa1c8320ba61fb437c7460ca