### PR TITLE
Improve error visibility in analytics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1937,13 +1937,29 @@ def generate_enhanced_analysis_updated(n_clicks, file_data, processed_data, devi
             return show_style, "Analysis complete! Enhanced metrics calculated."
 
         else:
-            hide_style = {"display": "none"}
-            return hide_style, "Error: Invalid processed data format"
+            show_style = {
+                "display": "block",
+                "width": "95%",
+                "margin": "20px auto",
+                "backgroundColor": COLORS["background"],
+                "borderRadius": "12px",
+                "padding": "20px",
+                "boxShadow": "0 4px 6px rgba(0, 0, 0, 0.1)",
+            }
+            return show_style, "Error: Invalid processed data format"
 
     except Exception as e:
         print(f"Error in analysis: {e}")
-        hide_style = {"display": "none"}
-        return hide_style, f"Error: {str(e)}"
+        show_style = {
+            "display": "block",
+            "width": "95%",
+            "margin": "20px auto",
+            "backgroundColor": COLORS["background"],
+            "borderRadius": "12px",
+            "padding": "20px",
+            "boxShadow": "0 4px 6px rgba(0, 0, 0, 0.1)",
+        }
+        return show_style, f"Error: {str(e)}"
 
 
 # Store enhanced stats data for consolidated container
@@ -2027,6 +2043,8 @@ def update_enhanced_stats_store_fixed(status_message, processed_data, device_cla
         Output("maintenance-alerts", "children"),
         Output("system-uptime", "children"),
         Output("most-active-devices-table-body", "children"),
+        Output("analytics-error-message", "children"),
+        Output("analytics-error-message", "style"),
     ],
     [
         Input("enhanced-stats-data-store", "data"),
@@ -2037,14 +2055,6 @@ def update_enhanced_stats_store_fixed(status_message, processed_data, device_cla
 def update_consolidated_analytics(enhanced_metrics, generate_clicks):
     """Update ALL analytics in the consolidated container"""
 
-    if not enhanced_metrics or not generate_clicks:
-        hide_style = {"display": "none"}
-        # Return placeholders matching the number of outputs
-        # There are 31 outputs besides the style, with the last
-        # being the most-active-devices table rows.
-        empty_values = ["N/A"] * 30
-        return [hide_style] + empty_values + [[]]
-
     show_style = {
         "display": "block",
         "width": "95%",
@@ -2054,6 +2064,26 @@ def update_consolidated_analytics(enhanced_metrics, generate_clicks):
         "padding": "20px",
         "boxShadow": "0 4px 6px rgba(0, 0, 0, 0.1)",
     }
+
+    error_style = {"display": "none"}
+    error_message = ""
+
+    if not enhanced_metrics and generate_clicks:
+        error_style = {
+            "display": "block",
+            "color": COLORS["critical"],
+            "textAlign": "center",
+            "marginBottom": "10px",
+        }
+        error_message = "Analytics data unavailable"
+        # Return placeholders
+        empty_values = ["N/A"] * 30
+        return [show_style] + empty_values + [[]] + [error_message, error_style]
+    elif not generate_clicks:
+        hide_style = {"display": "none"}
+        empty_values = ["N/A"] * 30
+        return [hide_style] + empty_values + [[]] + [error_message, error_style]
+
 
     metrics = enhanced_metrics or {}
 
@@ -2151,6 +2181,8 @@ def update_consolidated_analytics(enhanced_metrics, generate_clicks):
         traffic_pattern, behavioral, efficiency, trend,
         card_holders, session_duration, concurrent_users, security_events, maintenance, uptime,
         table_rows,
+        error_message,
+        error_style,
     ]
 
 

--- a/enhanced_stats.py
+++ b/enhanced_stats.py
@@ -67,6 +67,16 @@ class EnhancedStatsComponent:
             children=[
                 # Header Section
                 self.create_analytics_header(),
+                # Error message container (initially hidden)
+                html.Div(
+                    id="analytics-error-message",
+                    style={
+                        "color": COLORS["critical"],
+                        "textAlign": "center",
+                        "marginBottom": "10px",
+                        "display": "none",
+                    },
+                ),
                 
                 # Row 1: Core Statistics (Access Events, Users, Devices)
                 html.Div(

--- a/ui/components/graph_handlers.py
+++ b/ui/components/graph_handlers.py
@@ -91,7 +91,7 @@ class GraphHandlers:
             try:
                 df = pd.DataFrame(processed_data.get("dataframe", []))
                 if df.empty:
-                    return [], {"display": "none"}, "No data to generate graph"
+                    return [], {"display": "block"}, "No data to generate graph"
 
                 door_col = "DoorID (Device Name)"
                 ts_col = "Timestamp (Event Time)"
@@ -142,7 +142,7 @@ class GraphHandlers:
                 elements = nodes + list(unique_edges.values())
                 return elements, {"display": "block"}, "Analysis complete"
             except Exception:
-                return [], {"display": "none"}, "Failed to generate graph"
+                return [], {"display": "block"}, "Failed to generate graph"
 
 
 # Factory function


### PR DESCRIPTION
## Summary
- keep analytics container visible during errors and show an error message
- show graph container even when data cannot generate

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ab49f631483209b6af603b2f13bb0