### PR TITLE
Add dash testing suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ MODE=prod python run.py
 ```
 
 The script will start the development server when run in `dev` mode.  When `prod` is specified it uses Waitress to serve the app.
+
+## Testing
+
+A small test suite using `pytest` and `dash[testing]` ensures the application UI works as expected.  Install the additional testing dependencies and run the tests with:
+
+```bash
+pip install dash[testing] pytest
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ python-dateutil>=2.8.2
 requests>=2.31.0
 pydantic>=2.3.0
 psutil>=5.9.0
+dash[testing]>=2.14.1

--- a/tests/data/sample.csv
+++ b/tests/data/sample.csv
@@ -1,0 +1,3 @@
+Timestamp (Event Time),UserID (Person Identifier),DoorID (Device Name),EventType (Access Result)
+2021-01-01 09:00:00,User1,DoorA,ACCESS GRANTED
+2021-01-01 09:05:00,User2,DoorB,ACCESS GRANTED

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,25 @@
+import os
+import time
+import pytest
+from dash.testing.application_runners import import_app
+
+
+@pytest.fixture
+def app_runner():
+    app = import_app('app')
+    return app
+
+
+def test_generate_shows_analytics(dash_duo, app_runner):
+    dash_duo.start_server(app_runner)
+
+    upload_input = dash_duo.wait_for_element('input[type="file"]')
+    sample_path = os.path.join(os.path.dirname(__file__), 'data', 'sample.csv')
+    upload_input.send_keys(sample_path)
+
+    dash_duo.wait_for_element('#confirm-and-generate-button')
+    dash_duo.find_element('#confirm-and-generate-button').click()
+
+    analytic_container = dash_duo.wait_for_element('#analytic-stats-container', timeout=10)
+    assert analytic_container.value_of_css_property('display') != 'none'
+


### PR DESCRIPTION
## Summary
- add a simple dash[testing] test that uploads a file and clicks Generate
- include sample CSV test data
- document running tests in the README
- install dash[testing] in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*
- `pip install dash[testing] pytest` *(fails: Could not find a version that satisfies the requirement dash[testing])*

------
https://chatgpt.com/codex/tasks/task_e_684ab4a061c8832095dc4d9ad6d09edc