### PR TITLE
Refactor validation constants and add test

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,6 +103,7 @@ from ui.themes.style_config import (
     COLORS,
     TYPOGRAPHY,
     SPACING,
+    DEBUG_PANEL_STYLE,
 )
 from config.settings import DEFAULT_ICONS, REQUIRED_INTERNAL_COLUMNS, FILE_LIMITS
 
@@ -624,15 +625,12 @@ def create_debug_panel():
             ),
         ],
         style={
+            **DEBUG_PANEL_STYLE,
             "position": "fixed",
             "top": "10px",
             "right": "10px",
-            "backgroundColor": "#333",
-            "padding": "15px",
-            "borderRadius": "8px",
             "zIndex": "9999",
             "maxWidth": "300px",
-            "border": "1px solid #555",
         },
     )
 

--- a/tests/test_mapping_validator.py
+++ b/tests/test_mapping_validator.py
@@ -1,0 +1,11 @@
+import pytest
+from ui.components.mapping import MappingValidator
+from config.settings import REQUIRED_INTERNAL_COLUMNS
+
+
+def test_mapping_validator_with_empty_dict():
+    validator = MappingValidator(REQUIRED_INTERNAL_COLUMNS)
+    result = validator.validate_mapping({})
+    assert not result['is_valid']
+    assert len(result['missing_columns']) > 0
+

--- a/ui/themes/style_config.py
+++ b/ui/themes/style_config.py
@@ -314,6 +314,15 @@ LAYOUT_CONFIG = {
     }
 }
 
+# Style for the debug information panel used in the application
+DEBUG_PANEL_STYLE = {
+    "backgroundColor": COLORS["surface"],
+    "border": f"1px solid {COLORS['border']}",
+    "borderRadius": "8px",
+    "padding": "15px",
+    "marginTop": "20px",
+}
+
 # Centralized style definitions for UI components
 UPLOAD_STYLES = {
     'icon': {
@@ -694,6 +703,7 @@ __all__ = [
     'UI_VISIBILITY',
     'UI_COMPONENTS',
     'LAYOUT_CONFIG',
+    'DEBUG_PANEL_STYLE',
     'CSS_ANIMATIONS',
     
     # Enhanced style constants

--- a/utils/data_validator.py
+++ b/utils/data_validator.py
@@ -12,6 +12,10 @@ from utils.csv_validator import CSVValidator
 from ui.components.mapping import MappingValidator
 from config.settings import REQUIRED_INTERNAL_COLUMNS, FILE_LIMITS
 
+# Thresholds used across validation routines
+MAX_MISSING_PERCENTAGE_THRESHOLD = 50
+MAX_STRING_LENGTH_THRESHOLD = 1000
+
 class EnhancedDataValidator:
     """Enhanced data validation with detailed reporting"""
     
@@ -191,7 +195,7 @@ class EnhancedDataValidator:
             if df[col].dtype == 'object':
                 # Check for very long strings (possible data corruption)
                 max_length = df[col].astype(str).str.len().max()
-                if max_length > 1000:
+                if max_length > MAX_STRING_LENGTH_THRESHOLD:
                     self.validation_warnings.append(f"Column '{col}' has very long values (max: {max_length} chars)")
                 
                 # Check for unusual characters
@@ -327,7 +331,7 @@ class DataQualityAnalyzer:
         missing_data = analysis['missing_data']
         high_missing_columns = [
             col for col, stats in missing_data['by_column'].items()
-            if stats['missing_percentage'] > 50
+            if stats['missing_percentage'] > MAX_MISSING_PERCENTAGE_THRESHOLD
         ]
         
         if high_missing_columns:


### PR DESCRIPTION
## Summary
- move magic numbers in `data_validator` to module constants
- export debug panel style from theme config
- reuse `DEBUG_PANEL_STYLE` in the debug panel
- add basic test for `MappingValidator`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash' / 'ui')*

------
https://chatgpt.com/codex/tasks/task_e_684ad580deac83209f7bf180b5f4dd5b