### PR TITLE
Implement environment variable validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,11 +105,34 @@ from ui.themes.style_config import (
     SPACING,
     DEBUG_PANEL_STYLE,
 )
-from config.settings import DEFAULT_ICONS, REQUIRED_INTERNAL_COLUMNS, FILE_LIMITS
+from config.settings import (
+    DEFAULT_ICONS,
+    REQUIRED_INTERNAL_COLUMNS,
+    FILE_LIMITS,
+    get_config,
+)
 
 print(
     "🚀 Starting Yōsai Enhanced Analytics Dashboard (COMPLETE FIXED VERSION WITH TYPE SAFETY)..."
 )
+
+# Load and validate runtime configuration
+config = get_config()
+validation_report = config.validate_runtime_config()
+if not validation_report["valid"]:
+    print("❌ Configuration validation failed:")
+    for issue in validation_report["issues"]:
+        print(f"  - {issue}")
+    if any("does not exist" in issue for issue in validation_report["issues"]):
+        print("🚨 Critical configuration issues found. Exiting.")
+        exit(1)
+
+if validation_report["warnings"]:
+    print("⚠️ Configuration warnings:")
+    for warning in validation_report["warnings"]:
+        print(f"  - {warning}")
+
+print(f"✅ Configuration loaded: {config.host}:{config.port} (debug={config.debug})")
 
 # ============================================================================
 # ENHANCED IMPORTS WITH FALLBACK SUPPORT

--- a/test_env_validation.py
+++ b/test_env_validation.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Run environment variable validation tests."""
+
+import os
+import sys
+sys.path.insert(0, '.')
+
+from config.settings import test_environment_configuration
+
+if __name__ == "__main__":
+    test_environment_configuration()

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Test environment variable validation."""
+
+import os
+import sys
+sys.path.insert(0, '.')
+
+from config.settings import AppConfig
+
+
+def test_environment_validation_basic():
+    original_env = dict(os.environ)
+    try:
+        os.environ['PORT'] = '99999'
+        config = AppConfig.from_env()
+        assert config.port == 8050
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)


### PR DESCRIPTION
## Summary
- add robust environment variable validation helpers
- validate environment variables at startup and include docs
- export validation helpers through `__all__`
- add environment validation script and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python test_env_validation.py` *(fails: UnicodeEncodeError)*

------
https://chatgpt.com/codex/tasks/task_e_684af4d8b03c832084f7c01b7d37983b