### PR TITLE
Remove dev settings from Dash ctor

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -175,14 +175,10 @@ class AppFactory:
             ],
         }
         
-        if not is_production:
-            # Development-specific settings
-            config.update({
-                "dev_tools_hot_reload": True,
-                "dev_tools_ui": True,
-                "dev_tools_props_check": False,
-            })
-        
+
+        # Development tools are configured when running the server
+        # via run.py. The Dash constructor only contains core settings.
+
         return config
     
     def _get_server_config(self, is_production: bool) -> Dict[str, Any]:

--- a/run.py
+++ b/run.py
@@ -118,6 +118,7 @@ def run_development(app, host="127.0.0.1", port=8050, debug=True, **kwargs):
     print("=" * 50)
     
 
+    # Development tools are enabled here instead of in the Dash constructor
     app.run_server(
         debug=debug,
         host=host,


### PR DESCRIPTION
## Summary
- stop passing devtools flags via Dash constructor
- clarify in run.py that devtools run-server options are used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b40b067c8832080476d370f1c5d14