### PR TITLE
Fix decorator placement in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -688,7 +688,6 @@ def register_enhanced_callbacks_once(app: dash.Dash) -> None:
         ],
         prevent_initial_call=True,
     )
-    
 def populate_enhanced_stats_store(processed_data, generate_clicks, doors_data, classifications):
     """Populate the enhanced stats store with calculated metrics"""
     from dash import ctx


### PR DESCRIPTION
## Summary
- fix decorator placement for `populate_enhanced_stats_store`

## Testing
- `pytest -q` *(fails: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_684bb3de02a083209f3ae77c962db61b